### PR TITLE
Make project compatible with java 14 and up

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         scala-version: [2.13.8]
-        java-version: [8, 11]
+        java-version: [8, 11, 17]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2

--- a/src/main/scala/nl/gn0s1s/pureconfig/module/javanet/package.scala
+++ b/src/main/scala/nl/gn0s1s/pureconfig/module/javanet/package.scala
@@ -43,7 +43,7 @@ package object javanet {
   }
 
   implicit val inetSocketAddressConfigConvert: ConfigConvert[InetSocketAddress] =
-    ConfigConvert.viaNonEmptyString(s => parseHostAndPort(s), _.toString)
+    ConfigConvert.viaNonEmptyString(s => parseHostAndPort(s), address => s"${address.getHostString}:${address.getPort}")
 
   implicit val inetSocketAddressListConfigConvert: ConfigConvert[Seq[InetSocketAddress]] =
     ConfigConvert.viaNonEmptyString(
@@ -55,6 +55,8 @@ package object javanet {
           case _ =>
             Left(CannotConvert(s, "Seq[InetSocketAddress]", "Cannot parse string into hosts and ports"))
         },
-      _.mkString(",")
+      _.map { address =>
+        s"${address.getHostString}:${address.getPort}"
+      }.mkString(",")
     )
 }


### PR DESCRIPTION
Applying this PR will make the project compatible with Java 14 and up, since the `InetSocketAddress::toString`-method changed in Java 14 (https://www.oracle.com/java/technologies/javase/14all-relnotes.html#JDK-8225499) we cannot use that anymore for writing an address. Added Java 17 to the build as that is/will be an LTS version.