### PR TITLE
Support List[InetSocketAddress]

### DIFF
--- a/src/main/scala/nl/gn0s1s/pureconfig/module/javanet/package.scala
+++ b/src/main/scala/nl/gn0s1s/pureconfig/module/javanet/package.scala
@@ -45,7 +45,7 @@ package object javanet {
   implicit val inetSocketAddressConfigConvert: ConfigConvert[InetSocketAddress] =
     ConfigConvert.viaNonEmptyString(s => parseHostAndPort(s), address => s"${address.getHostString}:${address.getPort}")
 
-  implicit val inetSocketAddressListConfigConvert: ConfigConvert[Seq[InetSocketAddress]] =
+  implicit val inetSocketAddressSeqConfigConvert: ConfigConvert[Seq[InetSocketAddress]] =
     ConfigConvert.viaNonEmptyString(
       s =>
         s.split(", *")

--- a/src/main/scala/nl/gn0s1s/pureconfig/module/javanet/package.scala
+++ b/src/main/scala/nl/gn0s1s/pureconfig/module/javanet/package.scala
@@ -59,4 +59,7 @@ package object javanet {
         s"${address.getHostString}:${address.getPort}"
       }.mkString(",")
     )
+
+  implicit val inetSocketAddressListConfigConvert: ConfigConvert[List[InetSocketAddress]] =
+    inetSocketAddressSeqConfigConvert.xmap(_.toList, _.toList)
 }

--- a/src/test/scala/nl/gn0s1s/pureconfig/module/javanet/JavanetSuite.scala
+++ b/src/test/scala/nl/gn0s1s/pureconfig/module/javanet/JavanetSuite.scala
@@ -153,6 +153,26 @@ class JavanetSuite extends munit.FunSuite {
     )
   }
 
+  test("can read multiple addresses as a list") {
+    case class Config(hosts: List[InetSocketAddress])
+
+    val conf = parseString("""hosts: "localhost:65535,127.0.0.1:80,localhost:443"""")
+
+    assert(
+      conf
+        .to[Config]
+        .contains(
+          Config(
+            List(
+              InetSocketAddress.createUnresolved("localhost", 65535),
+              InetSocketAddress.createUnresolved("127.0.0.1", 80),
+              InetSocketAddress.createUnresolved("localhost", 443)
+            )
+          )
+        )
+    )
+  }
+
   test("can read a single address as multiple addresses") {
     case class Config(hosts: Seq[InetSocketAddress])
 
@@ -190,6 +210,18 @@ class JavanetSuite extends munit.FunSuite {
 
     assert(
       ConfigReader[Seq[InetSocketAddress]].from(ConfigWriter[Seq[InetSocketAddress]].to(addresses)).contains(addresses)
+    )
+  }
+
+  test("can read back a written List[InetSocketAddress]") {
+    val addresses = List(
+      InetSocketAddress.createUnresolved("localhost", 65535),
+      InetSocketAddress.createUnresolved("127.0.0.1", 80),
+      InetSocketAddress.createUnresolved("localhost", 443)
+    )
+
+    assert(
+      ConfigReader[List[InetSocketAddress]].from(ConfigWriter[List[InetSocketAddress]].to(addresses)).contains(addresses)
     )
   }
 

--- a/src/test/scala/nl/gn0s1s/pureconfig/module/javanet/JavanetSuite.scala
+++ b/src/test/scala/nl/gn0s1s/pureconfig/module/javanet/JavanetSuite.scala
@@ -143,7 +143,7 @@ class JavanetSuite extends munit.FunSuite {
         .to[Config]
         .contains(
           Config(
-            List(
+            Seq(
               InetSocketAddress.createUnresolved("localhost", 65535),
               InetSocketAddress.createUnresolved("127.0.0.1", 80),
               InetSocketAddress.createUnresolved("localhost", 443)
@@ -158,7 +158,7 @@ class JavanetSuite extends munit.FunSuite {
 
     val conf = parseString("""hosts: "localhost:65535"""")
 
-    assert(conf.to[Config].contains(Config(List(InetSocketAddress.createUnresolved("localhost", 65535)))))
+    assert(conf.to[Config].contains(Config(Seq(InetSocketAddress.createUnresolved("localhost", 65535)))))
   }
 
   test("is lenient about whitespace") {
@@ -171,7 +171,7 @@ class JavanetSuite extends munit.FunSuite {
         .to[Config]
         .contains(
           Config(
-            List(
+            Seq(
               InetSocketAddress.createUnresolved("localhost", 65535),
               InetSocketAddress.createUnresolved("127.0.0.1", 80),
               InetSocketAddress.createUnresolved("localhost", 443)


### PR DESCRIPTION
List is a commonly used collection type in configurations. For example, when defining the bootstrapServers in the monix-kafka KafkaConsumerConfig and KafkaProducerConfig.